### PR TITLE
resin-image-initramfs: Remove IMAGE_ROOTFS_MAXSIZE

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-core/images/resin-image-initramfs.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-core/images/resin-image-initramfs.bbappend
@@ -1,5 +1,2 @@
 # This fixes circular dependency error
 IMAGE_FSTYPES_imx8m-var-dart  = "${INITRAMFS_FSTYPES}"
-
-# This fixes rootfs maxsize override error
-IMAGE_ROOTFS_MAXSIZE = "16384"


### PR DESCRIPTION
Merge when bumped to 2.47

Since 2.47.0, IMAGE_ROOTFS_MAXSIZE is now 32M
in meta-balena-common

See https://github.com/balena-os/meta-balena/pull/1813 for more detail.

Changelog-entry: Cleanup unnecessary use of IMAGE_ROOTFS_MAXSIZE 
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>