### PR TITLE
Switch to M4 dtb, update BalenaOS

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/files/mx8mm-nrt-Enable-M4-run-from-DDR.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/files/mx8mm-nrt-Enable-M4-run-from-DDR.patch
@@ -1,34 +1,33 @@
-From 218e9e3a2ee2bddf8728e5841b3c7fd8acf10778 Mon Sep 17 00:00:00 2001
 From: Alexandru Costache <alexandru@balena.io>
 Date: Tue, 12 May 2020 10:39:58 +0200
-Subject: [PATCH] imx8mm-var-dart-nrt: Enable M4, run from TCM
+Subject: [PATCH] imx8mm-var-dart-nrt: Enable M4, run from DDR
 
 Enable the M4 core, set firmware binary name,
-set the DTB and let the binary reside in the TCM
-(as it came by default).
+set the DTB and let the binary reside in the DDR.
 
-Also, we stay on default DTB for now, as the M4 dtb:
-- disables ecspi1 (no spidev)
-- reserves DDR memory for the M4
-- sets up rpmsg for M4
+We do so as DDR was requested for rpmsg. At least
+3GB RAM are necessary to allow the M4 to access
+the RPMSG area according to the Variscite docs.
 
 Upstream-status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
- include/configs/imx8mm_var_dart.h | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ include/configs/imx8mm_var_dart.h | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/include/configs/imx8mm_var_dart.h b/include/configs/imx8mm_var_dart.h
-index 74173ba9b8..292f5023db 100644
+index deb86abfb7..e51c2cd7c3 100644
 --- a/include/configs/imx8mm_var_dart.h
 +++ b/include/configs/imx8mm_var_dart.h
-@@ -116,9 +116,9 @@
+@@ -115,10 +115,10 @@
+ 	"mmcblk=1\0" \
  	"mmcautodetect=yes\0" \
  	"mmcpart=1\0" \
- 	"m4_addr=0x7e0000\0" \
+-	"m4_addr=0x7e0000\0" \
 -	"m4_bin=hello_world.bin\0" \
 -	"use_m4=no\0" \
 -	"loadm4bin=load mmc ${mmcdev}:${mmcpart} ${m4_addr} ${bootdir}/${m4_bin}\0" \
++	"m4_addr=0x7e000000\0" \
 +	"m4_bin=m4_fw.bin\0" \
 +	"use_m4=yes\0" \
 +	"loadm4bin=load mmc ${mmcdev}:${resin_boot_part} ${m4_addr} ${m4_bin}\0" \
@@ -40,7 +39,7 @@ index 74173ba9b8..292f5023db 100644
  				"fi;" \
  			"else " \
 -				"setenv fdt_file fsl-imx8mm-var-dart.dtb;" \
-+				"setenv fdt_file fsl-imx8mm-var-dart.dtb;" \
++				"setenv fdt_file fsl-imx8mm-var-dart-m4.dtb;" \
  			"fi; " \
  		"fi; \0" \
  	"loadfdt=run findfdt; " \

--- a/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/u-boot-variscite.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/u-boot-variscite.bbappend
@@ -18,5 +18,5 @@ SRC_URI_append_imx8mm-var-dart-plt = " \
 "
 
 SRC_URI_append_imx8mm-var-dart-nrt = " \
-	file://mx8mm-nrt-Enable-M4-run-from-TCM.patch \
+	file://mx8mm-nrt-Enable-M4-run-from-DDR.patch \
 "


### PR DESCRIPTION
Now that rpmsg is requested as necessary, switch to M4 dtb and also switch m4 bin load address to DDR.