### PR TITLE
linux-variscite: Disable CQE for imx8mm-var-dart-nrt

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite/0007-arm64-dts-fsl-imx8mm-var-dart-Disable-CQE-for-the-eM.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite/0007-arm64-dts-fsl-imx8mm-var-dart-Disable-CQE-for-the-eM.patch
@@ -1,0 +1,29 @@
+From 6048b61590bd8721964f3ef896a9fdfe1c388ec9 Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@balena.io>
+Date: Thu, 9 Jul 2020 13:19:34 +0200
+Subject: [PATCH] arm64: dts:: fsl-imx8mm-var-dart: Disable CQE for the eMMC
+
+We have observed CQE presents some stability issues on a customer board
+so let's disable it.
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts b/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
+index 02c6291..e22cf1ee 100644
+--- a/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
++++ b/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
+@@ -1001,6 +1001,7 @@
+ 	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
+ 	bus-width = <8>;
+ 	non-removable;
++	no-cqe;
+ 	status = "okay";
+ };
+ 
+-- 
+2.7.4
+

--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -38,6 +38,7 @@ SRC_URI_append_imx8mm-var-dart = " \
 SRC_URI_append_imx8mm-var-dart-nrt = " \
 	file://0001-imx8mm-var-dart-nrt-pinmux.patch \
 	file://patch-4.14.93-rt53.patch \
+	file://0007-arm64-dts-fsl-imx8mm-var-dart-Disable-CQE-for-the-eM.patch \
 "
 
 RESIN_CONFIGS_append_imx8mm-var-dart-nrt = " preempt_rt"


### PR DESCRIPTION
We have observed CQE presents some stability issues on
imx8mm-var-dart-nrt so let's disable CQE for this board.

Changelog-entry: Disable CQE for imx8mm-var-dart-nrt
Signed-off-by: Florin Sarbu <florin@balena.io>