### PR TITLE
linux-variscite: Disable GPU for imx8mm-var-dart-nrt

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite/0008-dts-fsl-imx8mm-var-dart-Disable-GPU.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite/0008-dts-fsl-imx8mm-var-dart-Disable-GPU.patch
@@ -1,0 +1,29 @@
+From 1348ed0bbb5daa126aed6ef46223f0da235966ea Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@balena.io>
+Date: Fri, 10 Jul 2020 07:27:35 +0200
+Subject: [PATCH] dts: fsl-imx8mm-var-dart: Disable GPU
+
+This was requested by customer
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts b/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
+index 02c6291..0386ca2 100644
+--- a/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
++++ b/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
+@@ -1016,7 +1016,7 @@
+ };
+ 
+ &gpu {
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ &vpu_g1 {
+-- 
+2.7.4
+

--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -39,6 +39,7 @@ SRC_URI_append_imx8mm-var-dart-nrt = " \
 	file://0001-imx8mm-var-dart-nrt-pinmux.patch \
 	file://patch-4.14.93-rt53.patch \
 	file://0007-mmc-core-Disable-CQE.patch \
+	file://0008-dts-fsl-imx8mm-var-dart-Disable-GPU.patch \
 "
 
 RESIN_CONFIGS_append_imx8mm-var-dart-nrt = " preempt_rt"


### PR DESCRIPTION
This was requested by customer

Changelog-entry: Disable GPU for imx8mm-var-dart-nrt as requested by customer
Signed-off-by: Florin Sarbu <florin@balena.io>