### PR TITLE
Enable I2C commands in uboot for iMX8MM PLT

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/files/imx8mm-var-dart-Enable-I2C.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/files/imx8mm-var-dart-Enable-I2C.patch
@@ -1,0 +1,28 @@
+From 019735a9baa2666bd8b50d7ff98363e243fa613f Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Fri, 24 Jul 2020 11:12:56 +0200
+Subject: [PATCH] imx8mm-var-dart: Enable I2C in console
+
+Activate driver model for drivers to  have i2c commands
+working in u-boot cmdline on the iMX8M Mini VAR-DART.
+
+Works with VAR-DT8MCustomboard v1.4.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ configs/imx8mm_var_dart_defconfig | 1 +
+ 1 file changed, 1 insertions(+)
+
+diff --git a/configs/imx8mm_var_dart_defconfig b/configs/imx8mm_var_dart_defconfig
+index 7d2b6c6107..32a53cef43 100644
+--- a/configs/imx8mm_var_dart_defconfig
++++ b/configs/imx8mm_var_dart_defconfig
+@@ -67,3 +67,4 @@ CONFIG_CMD_EXT4=y
+ CONFIG_CMD_FAT=y
+ CONFIG_CMD_EXPORTENV=y
+ CONFIG_CMD_BOOTSWITCH_POS=y
++CONFIG_DM_I2C=y
+-- 
+2.17.1
+

--- a/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/u-boot-variscite.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/u-boot-variscite.bbappend
@@ -15,6 +15,7 @@ SRC_URI_append_imx8mm-var-dart = " \
 SRC_URI_append_imx8mm-var-dart-plt = " \
 	file://0001-Add-support-for-querying-boot-switch-position.patch \
 	file://0002-bootcmd-Flash-only-if-bootswitch-in-EXT-position.patch \
+	file://imx8mm-var-dart-Enable-I2C.patch \
 "
 
 SRC_URI_append_imx8mm-var-dart-nrt = " \


### PR DESCRIPTION
Tested with reading DS1307 rtc time on the DT8M Customboard v1.4

```
i2c bus
Bus 0:  i2c@30a20000  (active 0)
   52: generic_52, offset len 1, flags 0
Bus 1:  i2c@30a30000
Bus 2:  i2c@30a40000
u-boot=> i2c dev 1
Setting bus to 1
u-boot=> i2c probe
Valid chip addresses: 3D 54 55 68
u-boot=> i2c md 0x68 0 3
0000: 01 03 00    ...
```