### PR TITLE
u-boot: Do not add video kernel cmdline param for imx8mm-var-dart

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/files/dart-mx8mm-Integrate-with-Balena-u-boot-environment.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/files/dart-mx8mm-Integrate-with-Balena-u-boot-environment.patch
@@ -47,7 +47,7 @@ index 2ca74ef416..0ac8b21078 100644
 -	"mmcargs=setenv bootargs console=${console} " \
 -		"root=/dev/mmcblk${mmcblk}p${mmcpart} rootwait rw ${cma_size}\0 " \
 -	"loadbootscript=load mmc ${mmcdev}:${mmcpart} ${loadaddr} ${bootdir}/${script};\0" \
-+	"mmcargs=setenv bootargs console=${console}  video=${video} ${resin_kernel_root} rootwait rw ${os_cmdline} " \
++	"mmcargs=setenv bootargs console=${console} ${resin_kernel_root} rootwait rw ${os_cmdline} " \
 +		" ${cma_size}\0 " \
 +	"loadbootscript=load mmc ${mmcdev}:${mmcpart} ${loadaddr} ${script};\0" \
  	"bootscript=echo Running bootscript from mmc ...; " \


### PR DESCRIPTION
This was added as extra but it causes boot hang for the nrt board on which
we disabled the gpu. So let's just disable it and follow the original
mmcargs settings.

Changelog-entry: Remove video kernel cmdline param for imx8mm-var-dart based boards
Signed-off-by: Florin Sarbu <florin@balena.io>