### PR TITLE
u-boot-variscite: Remove console=null from prod imx8mm-var-dart-nrt

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/u-boot-variscite.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/u-boot-variscite.bbappend
@@ -28,3 +28,5 @@ SRC_URI_append_imx8mm-var-dart-plt = " \
 SRC_URI_append_imx8mm-var-dart-nrt = " \
 	file://mx8mm-nrt-Enable-M4-run-from-TCM.patch \
 "
+
+OS_KERNEL_CMDLINE_remove_imx8mm-var-dart-nrt = "console=null"


### PR DESCRIPTION
Using this kernel cmdline param the board will freeze at booting when
initializing the drm.

Changelog-entry: Remove console=null kernel cmdline param for imx8mm-var-dart-nrt
Signed-off-by: Florin Sarbu <florin@balena.io>