### PR TITLE
linux-variscite: Remove laird configs

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -14,13 +14,6 @@ RESIN_CONFIGS[imx-sdma] = " \
 		CONFIG_IMX_SDMA=m \
 "
 
-RESIN_CONFIGS_append_imx8mm-var-dart-plt = " laird"
-RESIN_CONFIGS[laird] = " \
-		CONFIG_CFG80211=n \
-		CONFIG_MAC80211=n \
-		CONFIG_BT=n \
-"
-
 # For plain imx8m-var-dart we'll stay at kernel 4.14.78
 # because there's no ubuntu release for 4.14.98, and
 # we want to preserve compatiblity for GPU access from container


### PR DESCRIPTION
These were removed as necessay for the laird
module. Now that's not being used anymore,
we need to add them back for on-board
wifi an bt.

Changelog-entry: linux-variscite: Remove laird configs
Signed-off-by: Alexandru Costache <alexandru@balena.io>