### PR TITLE
Switch PLT kernel to 4.14.98

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mm-var-dart-plt.conf
+++ b/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mm-var-dart-plt.conf
@@ -4,3 +4,5 @@
 
 MACHINEOVERRIDES = "imx8mm-var-dart:${MACHINE}"
 include conf/machine/imx8mm-var-dart.conf
+
+PREFERRED_VERSION_linux-variscite = "4.14.98"

--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_4.14.98.bb
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_4.14.98.bb
@@ -1,0 +1,67 @@
+# Copyright (C) 2013-2016 Freescale Semiconductor
+# Copyright 2017 NXP
+# Copyright 2018-2019 Variscite Ltd.
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "Linux kernel provided and supported by Variscite"
+DESCRIPTION = "Linux kernel provided and supported by Variscite (based on the kernel provided by NXP) \
+with focus on i.MX Family SOMs. It includes support for many IPs such as GPU, VPU and IPU."
+
+require recipes-kernel/linux/linux-imx.inc
+
+DEPENDS += "lzop-native bc-native"
+
+DEFAULT_PREFERENCE = "1"
+
+SRCBRANCH = "imx_4.14.98_2.0.0_ga_var01"
+SRCBRANCH_imx8mn-var-som = "imx_4.14.98_2.3.0_var01"
+
+LOCALVERSION_imx8mq-var-dart = "-imx8mq"
+LOCALVERSION_imx8mm-var-dart = "-imx8mm"
+LOCALVERSION_imx8mn-var-som = "-imx8mn"
+LOCALVERSION_imx8qxp-var-som = "-imx8x"
+LOCALVERSION_imx8qm-var-som = "-imx8qm"
+
+KERNEL_DEFCONFIG = "${S}/arch/arm64/configs/imx8_var_defconfig"
+DEFAULT_DTB_imx8mq-var-dart = "sd-lvds"
+DEFAULT_DTB_imx8qxp-var-som = "sd"
+DEFAULT_DTB_imx8qm-var-som = "lvds"
+DEFAULT_DTB_PREFIX_imx8mq-var-dart = "fsl-imx8mq-var-dart"
+DEFAULT_DTB_PREFIX_imx8qxp-var-som = "fsl-imx8qxp-var-som"
+DEFAULT_DTB_PREFIX_imx8qm-var-som = "fsl-imx8qm-var-som"
+
+KERNEL_SRC ?= "git://github.com/varigit/linux-imx;protocol=git"
+SRC_URI = "${KERNEL_SRC};branch=${SRCBRANCH}"
+SRCREV = "98788d5dc3bc8b019c1cad502d2d62aca36ec89a"
+SRCREV_imx8mn-var-som = "de780abac56b833822885dc748d1fdeb8ac17d75"
+
+S = "${WORKDIR}/git"
+
+addtask copy_defconfig after do_patch before do_preconfigure
+do_copy_defconfig () {
+    cp ${KERNEL_DEFCONFIG} ${WORKDIR}/defconfig
+}
+
+pkg_postinst_kernel-devicetree_append () {
+   rm -f $D/boot/devicetree-*
+}
+
+pkg_postinst_kernel-devicetree_append_imx8mq-var-dart () {
+    cd $D/boot
+    ln -s ${DEFAULT_DTB_PREFIX}-${DEFAULT_DTB}.dtb ${DEFAULT_DTB_PREFIX}.dtb
+    ln -s ${DEFAULT_DTB_PREFIX}-${DEFAULT_DTB}-cb12.dtb ${DEFAULT_DTB_PREFIX}-cb12.dtb
+}
+
+pkg_postinst_kernel-devicetree_append_imx8qxp-var-som () {
+    cd $D/boot
+    ln -s ${DEFAULT_DTB_PREFIX}-${DEFAULT_DTB}.dtb ${DEFAULT_DTB_PREFIX}.dtb
+}
+
+pkg_postinst_kernel-devicetree_append_imx8qm-var-som () {
+    cd $D/boot
+    ln -s ${DEFAULT_DTB_PREFIX}-${DEFAULT_DTB}.dtb ${DEFAULT_DTB_PREFIX}.dtb
+    ln -s fsl-imx8qm-var-spear-${DEFAULT_DTB}.dtb fsl-imx8qm-var-spear.dtb
+}
+
+COMPATIBLE_MACHINE = "(mx8)"
+EXTRA_OEMAKE_append_mx8 = " ARCH=arm64"


### PR DESCRIPTION
Removes
[Thu Sep 10 15:09:48 2020] Atheros 8031 ethernet 30be0000.ethernet-1:00: Master/Slave resolution failed, maybe conflicting manual settings?
[Thu Sep 10 15:09:48 2020] fec 30be0000.ethernet eth0: Link is Down

Patch that adds these is: https://patchwork.ozlabs.org/project/netdev/patch/60685308-a848-e4d0-e170-f2738f046679@gmail.com/
