### PR TITLE
linux-variscite: Disable commit SHA in version string

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -6,6 +6,9 @@ inherit kernel-resin
 # error caused by SRCPV
 LOCALVERSION = ""
 
+# Disable commit SHA in kernel version string
+SCMVERSION="n"
+
 # sdma driver tries to load the firmware
 # from initramfs causing bt to fail on plain mx8,
 # doesn't harm having it as module on all variants


### PR DESCRIPTION
Disable commit SHA in version string to avoid
version magic mismatch for modules.

Addresses: https://github.com/balena-os/balena-variscite-mx8/issues/15