### PR TITLE
linux-variscite: Disable PCIe for imx8mm-var-dart-plt

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite/imx8mm-var-dart-plt-Disable-PCIe.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite/imx8mm-var-dart-plt-Disable-PCIe.patch
@@ -1,0 +1,30 @@
+From 5d9592d4adb94e58417318e50648dfc146dd8f56 Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@balena.io>
+Date: Tue, 30 Mar 2021 09:56:29 +0200
+Subject: [PATCH] imx8mm-var-dart: Disable PCIe
+
+The hw vendor suggests we disable PCIe to have the new
+imx8mm-var-dart-plt revision boot correctly.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ arch/arm64/boot/dts/freescale/imx8mm-var-dart.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mm-var-dart.dts b/arch/arm64/boot/dts/freescale/imx8mm-var-dart.dts
+index 22b82a1..df50a73 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mm-var-dart.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mm-var-dart.dts
+@@ -936,7 +936,7 @@
+ 		 <&pcie0_refclk>;
+ 	clock-names = "pcie", "pcie_aux", "pcie_phy", "pcie_bus";
+ 	ext_osc = <1>;
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ /* Console */
+-- 
+2.7.4
+

--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -44,6 +44,7 @@ SRC_URI_append_imx8mm-var-dart-plt = " \
 	file://0007-mmc-core-Disable-CQE.patch \
 	file://0001-disable-gigabit.patch \
 	file://imx8mm-var-dart-plt-Switch-usb1-dr_mode-to-host.patch \
+	file://imx8mm-var-dart-plt-Disable-PCIe.patch \
 "
 
 BALENA_CONFIGS_append_imx8mm-var-dart-nrt = " preempt_rt"


### PR DESCRIPTION
The hw vendor suggests we disable PCIe to have the new
imx8mm-var-dart-plt revision boot correctly.

Changelog-entry: Disable PCIe for the new imx8mm-var-dart-plt revision to boot correctly
Signed-off-by: Florin Sarbu <florin@balena.io>