### PR TITLE
linux-variscite_%.bbappend: Disable ADS7846 for imx8mm-var-dart-plt

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -51,3 +51,8 @@ BALENA_CONFIGS_append_imx8mm-var-dart-nrt = " preempt_rt"
 BALENA_CONFIGS[preempt_rt] = " \
     CONFIG_PREEMPT_RT_FULL=y \
 "
+
+BALENA_CONFIGS_append_imx8mm-var-dart-plt = " disable_ads7846"
+BALENA_CONFIGS[disable_ads7846] = " \
+    CONFIG_TOUCHSCREEN_ADS7846=n \
+"


### PR DESCRIPTION
Touchscreen won't be used on the imx8mm-var-dart-plt board so let's
disable it so that we also free up gpio-3.

Changelog-entry: Disable ADS7846 touchscreen controller for imx8mm-var-dart-plt
Signed-off-by: Florin Sarbu <florin@balena.io>