### PR TITLE
linux-variscite: Updates for new NRT board pinmuxes

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite/0010-fsl-imx8mm-var-dart-Update-pinmux-for-NRT-board.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite/0010-fsl-imx8mm-var-dart-Update-pinmux-for-NRT-board.patch
@@ -1,21 +1,60 @@
-From 8b842f6780497c4dbcf7f1e188fe41f459897477 Mon Sep 17 00:00:00 2001
+From b8d9aa910eb190fdb174a83c6db3c13b8aa032d6 Mon Sep 17 00:00:00 2001
 From: Alexandru Costache <alexandru@balena.io>
 Date: Wed, 5 May 2021 11:31:14 +0200
 Subject: [PATCH] fsl-imx8mm-var-dart: Update pinmux for NRT board
 
-Changes are according to "New OS for Crown 1 - v1.1.0.pdf"
+Changes are according to "New OS ... 1 - v1.2.0.pdf"
 
 Upstream-status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
- .../dts/freescale/fsl-imx8mm-var-dart.dts     | 69 +++----------------
- 1 file changed, 11 insertions(+), 58 deletions(-)
+ .../dts/freescale/fsl-imx8mm-var-dart.dts     | 120 ++----------------
+ 1 file changed, 11 insertions(+), 109 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts b/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
-index da228a0bbae2..23dd9695fd2c 100644
+index da228a0bbae2..316c63d434c5 100644
 --- a/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
 +++ b/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
-@@ -198,6 +198,16 @@
+@@ -83,38 +83,6 @@
+ 		};
+ 	};
+ 
+-	sound-spdif {
+-		compatible = "fsl,imx-audio-spdif";
+-		model = "imx-spdif";
+-		spdif-controller = <&spdif1>;
+-		spdif-out;
+-		spdif-in;
+-		status = "disabled";
+-	};
+-
+-	sound-micfil {
+-		compatible = "fsl,imx-audio-micfil";
+-		model = "imx-audio-micfil";
+-		cpu-dai = <&micfil>;
+-		status = "disabled";
+-	};
+-
+-	sound-wm8904 {
+-		compatible = "fsl,imx-audio-wm8904";
+-		model = "imx-wm8904";
+-		audio-cpu = <&sai3>;
+-		audio-codec = <&wm8904>;
+-		audio-routing =
+-			"Headphone Jack", "HPOUTL",
+-			"Headphone Jack", "HPOUTR",
+-			"IN2L", "Line In Jack",
+-			"IN2R", "Line In Jack",
+-			"IN1L", "Mic Jack",
+-			"Playback", "CPU-Playback",
+-			"CPU-Capture", "Capture";
+-		status = "okay";
+-	};
+-
+ 	backlight: backlight {
+ 		compatible = "pwm-backlight";
+ 		pwms = <&pwm1 0 1000000 0>;
+@@ -198,6 +166,16 @@
  				MX8MM_IOMUXC_SAI3_TXD_GPIO5_IO1                0x140
  				MX8MM_IOMUXC_SAI3_TXC_GPIO5_IO0                0x140
  				MX8MM_IOMUXC_SPDIF_RX_GPIO5_IO4                0x140
@@ -32,7 +71,7 @@ index da228a0bbae2..23dd9695fd2c 100644
  			>;
  		};
  
-@@ -230,9 +240,7 @@
+@@ -230,9 +208,7 @@
  			fsl,pins = <
  				MX8MM_IOMUXC_NAND_ALE_QSPI_A_SCLK		0x1c2
  				MX8MM_IOMUXC_NAND_CE0_B_QSPI_A_SS0_B		0x82
@@ -42,7 +81,7 @@ index da228a0bbae2..23dd9695fd2c 100644
  				MX8MM_IOMUXC_NAND_DATA03_QSPI_A_DATA3		0x82
  			>;
  		};
-@@ -277,19 +285,8 @@
+@@ -277,19 +253,8 @@
  			>;
  		};
  
@@ -62,7 +101,7 @@ index da228a0bbae2..23dd9695fd2c 100644
  				MX8MM_IOMUXC_SAI5_RXC_PDM_CLK			0xd6
  				MX8MM_IOMUXC_SAI5_RXFS_SAI5_RX_SYNC		0xd6
  				MX8MM_IOMUXC_SAI5_RXD0_PDM_DATA0		0xd6
-@@ -319,13 +316,6 @@
+@@ -319,13 +284,6 @@
  			>;
  		};
  
@@ -76,7 +115,7 @@ index da228a0bbae2..23dd9695fd2c 100644
  		pinctrl_uart4: uart4grp {
  			fsl,pins = <
  				MX8MM_IOMUXC_ECSPI2_SCLK_UART4_DCE_RX		0x140
-@@ -499,13 +489,6 @@
+@@ -499,13 +457,6 @@
  			>;
  		};
  
@@ -90,7 +129,7 @@ index da228a0bbae2..23dd9695fd2c 100644
  		pinctrl_ecspi1: ecspi1grp {
  			fsl,pins = <
  				MX8MM_IOMUXC_ECSPI1_SCLK_ECSPI1_SCLK		0x13
-@@ -728,22 +711,6 @@
+@@ -728,22 +679,6 @@
  	pinctrl-0 = <&pinctrl_i2c2>;
  	status = "okay";
  
@@ -113,7 +152,33 @@ index da228a0bbae2..23dd9695fd2c 100644
  	ov5640_mipi1: ov5640_mipi1@3c {
  		status = "okay";
  		compatible = "ovti,ov5640_mipi";
-@@ -850,15 +817,6 @@
+@@ -789,25 +724,6 @@
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_i2c3>;
+ 	status = "okay";
+-
+-	wm8904: codec@1a {
+-		compatible = "wlf,wm8904";
+-		reg = <0x1a>;
+-		clocks = <&clk IMX8MM_CLK_SAI3_ROOT>;
+-		clock-names = "mclk";
+-		DCVDD-supply = <&ldo5_reg>;
+-		DBVDD-supply = <&reg_audio>;
+-		AVDD-supply = <&ldo5_reg>;
+-		CPVDD-supply = <&ldo5_reg>;
+-		MICVDD-supply = <&ldo5_reg>;
+-		status = "okay";
+-		gpio-cfg = <
+-			0x0018 /* GPIO1 => DMIC_CLK */
+-			0xffff /* GPIO2 => don't touch */
+-			0xffff /* GPIO3 => don't touch */
+-			0xffff /* GPIO4 => don't touch */
+-		>;
+-	};
+ };
+ 
+ &i2c4 {
+@@ -850,15 +766,6 @@
  	status = "okay";
  };
  
@@ -129,7 +194,7 @@ index da228a0bbae2..23dd9695fd2c 100644
  &spdif1 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&pinctrl_spdif1>;
-@@ -923,12 +881,7 @@
+@@ -923,12 +830,7 @@
  	status = "okay";
  };
  


### PR DESCRIPTION
User wants to use GPIO5_IO01, let's remove the wm8904 node
which modified this.

Changelog-entry: linux-variscite: Updates for new NRT hw pinmuxes
Signed-off-by: Alexandru Costache <alexandru@balena.io>