### PR TITLE
gitmodules: Update to use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,10 +3,10 @@
 	url = https://github.com/balena-os/balena-yocto-scripts.git
 [submodule "layers/meta-freescale"]
 	path = layers/meta-freescale
-	url = git://git.yoctoproject.org/meta-freescale
+	url = https://git.yoctoproject.org/git/meta-freescale
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
-	url = git://github.com/openembedded/meta-openembedded
+	url = https://github.com/openembedded/meta-openembedded.git
 [submodule "layers/meta-balena"]
 	path = layers/meta-balena
 	url = https://github.com/balena-os/meta-balena.git


### PR DESCRIPTION
versionbot does not support ssh

Changelog-entry: update git submodules to use https
Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>