### PR TITLE
imx8mm-var-dart-nrt: Add LP55231 driver and dt entry

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite/0011-imx8mm-var-dart-nrt-Add-LP55231-to-the-device-tree.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite/0011-imx8mm-var-dart-nrt-Add-LP55231-to-the-device-tree.patch
@@ -1,0 +1,76 @@
+From 9c7520bd3c4364f7eb46f4276cc433566528b4ad Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Mon, 17 May 2021 11:08:25 +0200
+Subject: [PATCH] imx8mm-var-dart-nrt: Add LP55231 to the device tree
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ .../dts/freescale/fsl-imx8mm-var-dart.dts     | 51 +++++++++++++++++++
+ 1 file changed, 51 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts b/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
+index 316c63d434c5..0a8bd82113a7 100644
+--- a/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
++++ b/arch/arm64/boot/dts/freescale/fsl-imx8mm-var-dart.dts
+@@ -717,6 +717,57 @@
+ 		interrupt-parent = <&gpio1>;
+ 		interrupts = <15 IRQ_TYPE_EDGE_FALLING>;
+ 	};
++
++	lp55231@30 {
++		compatible = "ti,lp55231";
++		reg = <0x30>;
++		clock-mode = /bits/ 8 <1>;
++		chan0 {
++			chan-name = "d1";
++			led-cur = /bits/ 8 <0xfa>;
++			max-cur = /bits/ 8 <0xff>;
++		};
++		chan1 {
++			chan-name = "d2";
++			led-cur = /bits/ 8 <0xfa>;
++			max-cur = /bits/ 8 <0xff>;
++		};
++		chan2 {
++			chan-name = "d3";
++			led-cur = /bits/ 8 <0xfa>;
++			max-cur = /bits/ 8 <0xff>;
++		};
++		chan3 {
++			chan-name = "d4";
++			led-cur = /bits/ 8 <0xfa>;
++			max-cur = /bits/ 8 <0xff>;
++		};
++		chan4 {
++			chan-name = "d5";
++			led-cur = /bits/ 8 <0xfa>;
++			max-cur = /bits/ 8 <0xff>;
++		};
++		chan5 {
++			chan-name = "d6";
++			led-cur = /bits/ 8 <0xfa>;
++			max-cur = /bits/ 8 <0xff>;
++		};
++		chan6 {
++			chan-name = "d7";
++			led-cur = /bits/ 8 <0xfa>;
++			max-cur = /bits/ 8 <0xff>;
++		};
++		chan7 {
++			chan-name = "d8";
++			led-cur = /bits/ 8 <0xfa>;
++			max-cur = /bits/ 8 <0xff>;
++		};
++		chan8 {
++			chan-name = "d9";
++			led-cur = /bits/ 8 <0xfa>;
++			max-cur = /bits/ 8 <0xff>;
++		};
++	};
+ };
+ 
+ &i2c3 {
+-- 
+2.17.1
+

--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -39,6 +39,7 @@ SRC_URI_append_imx8mm-var-dart-nrt = " \
 	file://0008-dts-fsl-imx8mm-var-dart-Disable-GPU.patch \
 	file://0009-Port-RT-changes-4.19.31-rt18.patch \
 	file://0010-fsl-imx8mm-var-dart-Update-pinmux-for-NRT-board.patch \
+	file://0011-imx8mm-var-dart-nrt-Add-LP55231-to-the-device-tree.patch \
 "
 
 SRC_URI_append_imx8mm-var-dart-plt = " \
@@ -51,4 +52,9 @@ SRC_URI_append_imx8mm-var-dart-plt = " \
 BALENA_CONFIGS_append_imx8mm-var-dart-nrt = " preempt_rt"
 BALENA_CONFIGS[preempt_rt] = " \
     CONFIG_PREEMPT_RT_FULL=y \
+"
+
+BALENA_CONFIGS_append_imx8mm-var-dart-nrt = " lp55231"
+BALENA_CONFIGS[lp55231] = " \
+    CONFIG_LEDS_LP5523=m \
 "


### PR DESCRIPTION
Connects to: https://github.com/balena-os/balena-variscite-mx8/issues/83

Changelog-entry: imx8mm-var-dart-nrt: Add LP55231 driver and dt entry
Signed-off-by: Alexanru Costache <alexandru@balena.io>