### PR TITLE
NRT: Add support for default LP55231 brightness configuration at startup

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite-5.4.85/0001-lp55xx-Add-support-for-default-startup-brightness-fr.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite-5.4.85/0001-lp55xx-Add-support-for-default-startup-brightness-fr.patch
@@ -1,0 +1,65 @@
+From 07981a4c920f8b83f5cd3f31dd1d7f8c37632c2e Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Tue, 26 Apr 2022 13:52:14 +0200
+Subject: [PATCH] lp55xx: Add support for default startup brightness from dtb
+
+JF ticket https://jel.ly.fish/support-thread-1-0-0-front-cnv-ceqsqz1
+requests for all d1-d8 of the LP55231 chip to be set from OS
+startup to brightness = 255 and current = 10;
+
+U-boot sets these values already but the led is turned off
+as soon as the kernel driver is loaded. Turning it back on
+once the container application starts is too late and adding
+a systemd service would also cause a significant delay. Also,
+setting the desired values from an udev rule would trigrer a
+short flashing red color, which is noticeable.
+
+We thus add support for using a default brightness from the
+device-tree, and adapt it and the led_current to the requested
+values provided by the customer in the above ticket.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ drivers/leds/leds-lp55xx-common.c         | 5 +++++
+ include/linux/platform_data/leds-lp55xx.h | 1 +
+ 2 files changed, 6 insertions(+)
+
+diff --git a/drivers/leds/leds-lp55xx-common.c b/drivers/leds/leds-lp55xx-common.c
+index 44ced02b49f9..98fb83f99931 100644
+--- a/drivers/leds/leds-lp55xx-common.c
++++ b/drivers/leds/leds-lp55xx-common.c
+@@ -485,6 +485,9 @@ int lp55xx_register_leds(struct lp55xx_led *led, struct lp55xx_chip *chip)
+ 		/* setting led current at each channel */
+ 		if (cfg->set_led_current)
+ 			cfg->set_led_current(each, led_current);
++
++                each->brightness = pdata->led_config[i].default_brightness;
++                cfg->brightness_fn(each);
+ 	}
+ 
+ 	return 0;
+@@ -570,6 +573,8 @@ struct lp55xx_platform_data *lp55xx_of_populate_pdata(struct device *dev,
+ 		of_property_read_string(child, "chan-name", &cfg[i].name);
+ 		of_property_read_u8(child, "led-cur", &cfg[i].led_current);
+ 		of_property_read_u8(child, "max-cur", &cfg[i].max_current);
++		if (of_property_read_u8(child, "default-brightness", &cfg[i].default_brightness))
++			cfg[i].default_brightness = 0;
+ 		cfg[i].default_trigger =
+ 			of_get_property(child, "linux,default-trigger", NULL);
+ 
+diff --git a/include/linux/platform_data/leds-lp55xx.h b/include/linux/platform_data/leds-lp55xx.h
+index 96a787100fda..60af2a771937 100644
+--- a/include/linux/platform_data/leds-lp55xx.h
++++ b/include/linux/platform_data/leds-lp55xx.h
+@@ -23,6 +23,7 @@ struct lp55xx_led_config {
+ 	u8 chan_nr;
+ 	u8 led_current; /* mA x10, 0 if led is not connected */
+ 	u8 max_current;
++	u8 default_brightness;
+ };
+ 
+ struct lp55xx_predef_pattern {
+-- 
+2.17.1
+

--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite-5.4.85/imx8mm-var-dart-nrt-Add-LP55231-to-the-device-tree.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite-5.4.85/imx8mm-var-dart-nrt-Add-LP55231-to-the-device-tree.patch
@@ -1,4 +1,4 @@
-From 30863ed7eff0a99683e65798df58ec5600f647a0 Mon Sep 17 00:00:00 2001
+From 929207868ca6fbe246f342e3913e353775007f0d Mon Sep 17 00:00:00 2001
 From: Alexandru Costache <alexandru@balena.io>
 Date: Thu, 12 Aug 2021 12:49:18 +0200
 Subject: [PATCH] imx8mm-var-dart-nrt: Add LP55231 to the device tree
@@ -6,71 +6,84 @@ Subject: [PATCH] imx8mm-var-dart-nrt: Add LP55231 to the device tree
 Use address 0x32 and I2C3 (bus 2) as per the updated
 request from the user.
 
+Set default brightness to 255 and default led current
+to 10 at module load, as requrested by the customer in
+https://jel.ly.fish/support-thread-1-0-0-front-cnv-ceqsqz1
+
 Upstream-status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
- .../boot/dts/freescale/imx8mm-var-dart.dtsi   | 55 +++++++++++++++++++
- 1 file changed, 55 insertions(+)
+ .../boot/dts/freescale/imx8mm-var-dart.dtsi   | 64 +++++++++++++++++++
+ 1 file changed, 64 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-var-dart.dtsi b/arch/arm64/boot/dts/freescale/imx8mm-var-dart.dtsi
-index 67065e8a4580..0cae1b83e294 100644
+index 67065e8a4580..34761c282734 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-var-dart.dtsi
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-var-dart.dtsi
-@@ -514,6 +514,61 @@
+@@ -514,6 +514,70 @@
  	scl-gpios = <&gpio5 18 GPIO_ACTIVE_HIGH>;
  	sda-gpios = <&gpio5 19 GPIO_ACTIVE_HIGH>;
  	status = "okay";
 +
 +	lp55231@32 {
-+	        compatible = "ti,lp55231";
-+        	reg = <0x32>;
-+	        clock-mode = /bits/ 8 <1>;
++		compatible = "ti,lp55231";
++		reg = <0x32>;
++		clock-mode = /bits/ 8 <1>;
 +
-+	        chan0 {
-+        	        chan-name = "d1";
-+                	led-cur = /bits/ 8 <0xfa>;
-+	                max-cur = /bits/ 8 <0xff>;
-+        	};
-+	        chan1 {
-+        	        chan-name = "d2";
-+                	led-cur = /bits/ 8 <0xfa>;
-+	                max-cur = /bits/ 8 <0xff>;
-+        	};
-+	        chan2 {
-+        	        chan-name = "d3";
-+                	led-cur = /bits/ 8 <0xfa>;
-+	                max-cur = /bits/ 8 <0xff>;
-+        	};
-+	        chan3 {
-+        	        chan-name = "d4";
-+                	led-cur = /bits/ 8 <0xfa>;
-+	                max-cur = /bits/ 8 <0xff>;
-+        	};
-+	        chan4 {
-+        	        chan-name = "d5";
-+                	led-cur = /bits/ 8 <0xfa>;
-+	                max-cur = /bits/ 8 <0xff>;
-+        	};
-+	        chan5 {
-+        	        chan-name = "d6";
-+                	led-cur = /bits/ 8 <0xfa>;
-+	                max-cur = /bits/ 8 <0xff>;
-+        	};
-+	        chan6 {
-+        	        chan-name = "d7";
-+                	led-cur = /bits/ 8 <0xfa>;
-+	                max-cur = /bits/ 8 <0xff>;
-+        	};
-+	        chan7 {
-+        	        chan-name = "d8";
-+	                led-cur = /bits/ 8 <0xfa>;
-+        	        max-cur = /bits/ 8 <0xff>;
-+	        };
-+	        chan8 {
-+        	        chan-name = "d9";
-+                	led-cur = /bits/ 8 <0xfa>;
-+	                max-cur = /bits/ 8 <0xff>;
-+        	};
++		chan0 {
++			chan-name = "d1";
++			led-cur = /bits/ 8 <0x0a>;
++			max-cur = /bits/ 8 <0xff>;
++			default-brightness = /bits/ 8 <0xff>;
++		};
++		chan1 {
++			chan-name = "d2";
++			led-cur = /bits/ 8 <0x0a>;
++			max-cur = /bits/ 8 <0xff>;
++			default-brightness = /bits/ 8 <0xff>;
++		};
++		chan2 {
++			chan-name = "d3";
++			led-cur = /bits/ 8 <0x0a>;
++			max-cur = /bits/ 8 <0xff>;
++			default-brightness = /bits/ 8 <0xff>;
++		};
++		chan3 {
++			chan-name = "d4";
++			led-cur = /bits/ 8 <0x0a>;
++			max-cur = /bits/ 8 <0xff>;
++			default-brightness = /bits/ 8 <0xff>;
++		};
++		chan4 {
++			chan-name = "d5";
++			led-cur = /bits/ 8 <0x0a>;
++			max-cur = /bits/ 8 <0xff>;
++			default-brightness = /bits/ 8 <0xff>;
++		};
++		chan5 {
++			chan-name = "d6";
++			led-cur = /bits/ 8 <0x0a>;
++			max-cur = /bits/ 8 <0xff>;
++			default-brightness = /bits/ 8 <0xff>;
++		};
++		chan6 {
++			chan-name = "d7";
++			led-cur = /bits/ 8 <0x0a>;
++			max-cur = /bits/ 8 <0xff>;
++			default-brightness = /bits/ 8 <0xff>;
++		};
++		chan7 {
++			chan-name = "d8";
++			led-cur = /bits/ 8 <0x0a>;
++			max-cur = /bits/ 8 <0xff>;
++			default-brightness = /bits/ 8 <0xff>;
++		};
++		chan8 {
++			chan-name = "d9";
++			led-cur = /bits/ 8 <0x0a>;
++			max-cur = /bits/ 8 <0xff>;
++			default-brightness = /bits/ 8 <0xff>;
++		};
 +	};
 +
 +

--- a/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -35,7 +35,8 @@ SRC_URI_append_imx8mm-var-dart-nrt = " \
 	file://fsl-imx8mm-var-dart-nrt-Port-pinmux-for-NRT-board-to-ker-5-4-85.patch \
 	file://fsl-imx8mm-var-dart-nrt-pinmux-legacy-nrt.patch \
 	file://imx8mm-var-dart-nrt-Add-LP55231-to-the-device-tree.patch \
-        file://imx8mm-var-dart-plt-Disable-PCIe.patch \
+	file://imx8mm-var-dart-plt-Disable-PCIe.patch \
+	file://0001-lp55xx-Add-support-for-default-startup-brightness-fr.patch \
 "
 
 SRC_URI_append_imx8mm-var-dart-plt = " \


### PR DESCRIPTION
According to: https://jel.ly.fish/support-thread-1-0-0-front-cnv-ceqsqz1