### PR TITLE
u-boot: Use old imx-boot on imx8mm-var-dart-plt during rollback

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/files/Use-old-device-tree-on-altboot.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-bsp/u-boot/files/Use-old-device-tree-on-altboot.patch
@@ -1,6 +1,6 @@
-From 03a7177b86816210d538eb09f200888b3fbad4a6 Mon Sep 17 00:00:00 2001
+From 015cde7dc2c54c63ab959b191e369b47440fa93d Mon Sep 17 00:00:00 2001
 From: Alexandru Costache <alexandru@balena.io>
-Date: Wed, 30 Jun 2021 10:07:17 +0200
+Date: Sat, 21 May 2022 23:08:09 +0200
 Subject: [PATCH] Use old device tree on altboot
 
 Variscite renamed device trees starting with
@@ -10,21 +10,28 @@ device tree name in case of a rollback.
 Upstream-status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
 ---
- include/configs/imx8mm_var_dart.h | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ include/configs/imx8mm_var_dart.h | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/include/configs/imx8mm_var_dart.h b/include/configs/imx8mm_var_dart.h
-index 0b323ac844..0589d0d134 100644
+index b722fba0e9..dd13f40105 100644
 --- a/include/configs/imx8mm_var_dart.h
 +++ b/include/configs/imx8mm_var_dart.h
-@@ -133,8 +133,8 @@
+@@ -132,9 +132,15 @@
+ 				"fi; " \
  			"fi; " \
  		"fi; \0" \
++	"imx_boot_bin=imx-boot-imx8mm-var-dart-plt-sd.bin-flash_lpddr4_ddr4_evk\0" \
++	"set_num_blocks=setexpr imx_boot_num_blocks ${filesize} / 0x200 ; setexpr imx_boot_num_blocks ${imx_boot_num_blocks} + 1; echo imx-boot has ${imx_boot_num_blocks} blocks; \0" \
++	"revert_imx_boot=load mmc ${mmcdev}:${resin_root_part} ${loadaddr} boot/${imx_boot_bin} ; " \
++                       "run set_num_blocks; mmc write ${loadaddr} 0x42 ${imx_boot_num_blocks}; reset; \0" \
  	"loadfdt=run findfdt; " \
 -		"echo fdt_file=${fdt_file}; " \
 -		"load mmc ${mmcdev}:${resin_root_part} ${fdt_addr} boot/${fdt_file}\0" \
-+		"echo fdt_file=${fdt_file}; setenv old_fdt imx8mm-var-dart.dtb; " \
-+		"if load mmc ${mmcdev}:${resin_root_part} ${fdt_addr} boot/${fdt_file}; then echo Loaded ${fdt_file}; else load mmc ${mmcdev}:${resin_root_part} ${fdt_addr} boot/${old_fdt}; echo Using old dt!; fi;\0" \
++		"echo fdt_file=${fdt_file}; setenv old_fdt imx8mm-var-dart-legacy.dtb; " \
++		"if load mmc ${mmcdev}:${resin_root_part} ${fdt_addr} boot/${fdt_file}; then echo Loaded ${fdt_file}; " \
++		"else if load mmc ${mmcdev}:${resin_root_part} ${fdt_addr} boot/${old_fdt}; then echo Using old legacy dt!; " \
++		"else if test ${mmcdev} = 2; then echo Will revert imx-boot for compatibility; run revert_imx_boot; fi; fi; fi; \0" \
  	"ramsize_check="\
  		"if test $sdram_size -le 512; then " \
  			"setenv cma_size cma=320M; " \


### PR DESCRIPTION
We need to use the corresponding imx-boot binary during
rollback-altboot if the kernel and device-tree are
older than the current 5.4.24 imx-boot, otherwise the old kernel will
hang when booted with a newer imx-boot.

We thus write the old version of imx-boot during rollback-altboot
if the device-tree name in the old rootfs does not correspond to
the latest upstream naming scheme.

Changelog-entry: u-boot: Use old imx-boot on imx8mm-var-dart-plt during rollback
Signed-off-by: Alexandru Costache <alexandru@balena.io>