### PR TITLE
balena-image: fix extra_uEnv.txt not included due to undefined UBOOT_…

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-imx8m-var-dart/recipes-core/images/balena-image.inc
@@ -41,6 +41,10 @@ BALENA_BOOT_PARTITION_FILES_imx8mm-var-dart = " \
     imx8mm-var-dart-dt8mcustomboard-m4.dtb:/imx8mm-var-dart-dt8mcustomboard-m4.dtb \
 "
 
+BALENA_BOOT_PARTITION_FILES_append = " \
+    extra_uEnv.txt:/extra_uEnv.txt \
+"
+
 IMAGE_INSTALL_append = " \
 	imx-boot \
 	bcm43xx-utils \


### PR DESCRIPTION
…MACHINE

The BSP does not define UBOOT_MACHINE, instead
it uses UBOOT_CONFIG. We will extend the check
for UBOOT_CONFIG in meta-balena, until then
we add this workaround in the device repository.

Changelog-entry: fix extra_uEnv.txt not included due to undefined UBOOT_MACHINE
Signed-off-by: Alexandru Costache <alexandru@balena.io>