### PR TITLE
[DO NOT MERGE] bluez: Remove battery profile

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/conf/layer.conf
+++ b/layers/meta-balena-imx8m-var-dart/conf/layer.conf
@@ -5,7 +5,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "balena-imx8m-var-dart"
 BBFILE_PATTERN_balena-imx8m-var-dart := "^${LAYERDIR}/"
-BBFILE_PRIORITY_balena-imx8m-var-dart = "1337"
+BBFILE_PRIORITY_balena-imx8m-var-dart = "1100"
 
 LAYERSERIES_COMPAT_balena-imx8m-var-dart = "warrior dunfell"
 

--- a/layers/meta-balena-imx8m-var-dart/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/files"

--- a/layers/meta-balena-imx8m-var-dart/recipes-connectivity/bluez5/files/bluetooth.conf.systemd
+++ b/layers/meta-balena-imx8m-var-dart/recipes-connectivity/bluez5/files/bluetooth.conf.systemd
@@ -1,0 +1,7 @@
+[Unit]
+Requires=bind-var-lib-bluetooth.service
+After=bind-var-lib-bluetooth.service
+
+[Service]
+ExecStart=
+ExecStart=@pkglibexecdir@/bluetooth/bluetoothd --experimental -P battery


### PR DESCRIPTION
Internal: Related to https://jel.ly.fish/support-thread-1-0-0-front-cnv-by16i4t

Some devices have trouble authenticating when the battery profile is
enabled, see https://github.com/bluez/bluez/issues/38

Changelog-entry: Remove battery profile from bluetooth daemon
Signed-off-by: Alex Gonzalez <alexg@balena.io>