### PR TITLE
imx8mm-var-dart-nrt: do not set ROOTFS_SIZE

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/conf/machine/imx8m-var-dart.conf
+++ b/layers/meta-balena-imx8m-var-dart/conf/machine/imx8m-var-dart.conf
@@ -3,4 +3,4 @@
 ##@DESCRIPTION: Machine configuration for the imx8m-var-dart
 
 MACHINEOVERRIDES = "imx8mq-var-dart:${MACHINE}"
-include conf/machine/imx8mq-var-dart.conf
+include conf/machine/imx8mq-var-dart.inc

--- a/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mm-var-dart-nrt.conf
+++ b/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mm-var-dart-nrt.conf
@@ -3,4 +3,4 @@
 ##@DESCRIPTION: Machine configuration for the imx8mm-var-dart-nrt
 
 MACHINEOVERRIDES = "imx8mm-var-dart:${MACHINE}"
-include conf/machine/imx8mm-var-dart.conf
+include conf/machine/imx8mm-var-dart.inc

--- a/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mm-var-dart-plt.conf
+++ b/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mm-var-dart-plt.conf
@@ -3,5 +3,5 @@
 ##@DESCRIPTION: Machine configuration for the imx8mm-var-dart-plt
 
 MACHINEOVERRIDES = "imx8mm-var-dart:${MACHINE}"
-include conf/machine/imx8mm-var-dart.conf
+include conf/machine/imx8mm-var-dart.inc
 

--- a/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mm-var-dart.inc
+++ b/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mm-var-dart.inc
@@ -1,0 +1,63 @@
+#@TYPE: Machine
+#@NAME: Variscite DART-MX8M-MINI
+#@SOC: i.MX8MM
+#@DESCRIPTION: Machine configuration for Variscite DART-MX8M-MINI and VAR-SOM-MX8M-MINI
+#@MAINTAINER: Felix Radensky <felix.r@variscite.com>
+#
+# http://www.variscite.com
+
+MACHINEOVERRIDES =. "mx8:mx8m:mx8mm:"
+require conf/machine/include/imx-base.inc
+require conf/machine/include/tune-cortexa53.inc
+
+require conf/machine/variscite.inc
+require conf/machine/variscite_bcm43xx.inc
+
+KERNEL_DEVICETREE = " \
+	freescale/imx8mm-var-dart-dt8mcustomboard.dtb \
+	freescale/imx8mm-var-dart-dt8mcustomboard-legacy.dtb \
+	freescale/imx8mm-var-som-symphony.dtb \
+	freescale/imx8mm-var-som-symphony-legacy.dtb \
+	freescale/imx8mm-var-dart-dt8mcustomboard-m4.dtb \
+	freescale/imx8mm-var-dart-dt8mcustomboard-legacy-m4.dtb \
+	freescale/imx8mm-var-som-symphony-m4.dtb \
+	freescale/imx8mm-var-som-symphony-legacy-m4.dtb \
+"
+
+IMAGE_BOOTFILES_DEPENDS += "imx-m4-demos:do_deploy"
+IMAGE_BOOTFILES += "imx8mm_m4_TCM_hello_world.bin \
+                    imx8mm_m4_TCM_rpmsg_lite_pingpong_rtos_linux_remote.bin \
+                    imx8mm_m4_TCM_rpmsg_lite_str_echo_rtos.bin \
+                    imx8mm_m4_TCM_sai_low_power_audio.bin \
+"
+
+UBOOT_CONFIG ??= "sd"
+UBOOT_CONFIG[sd] = "imx8mm_var_dart_config,sdcard"
+SPL_BINARY = "spl/u-boot-spl.bin"
+
+# Set DDR FIRMWARE
+DDR_FIRMWARE_NAME = " \
+	ddr4_imem_1d.bin \
+	ddr4_dmem_1d.bin \
+	ddr4_imem_2d.bin \
+	ddr4_dmem_2d.bin \
+	lpddr4_pmu_train_1d_imem.bin \
+	lpddr4_pmu_train_1d_dmem.bin \
+	lpddr4_pmu_train_2d_imem.bin \
+	lpddr4_pmu_train_2d_dmem.bin \
+"
+# Set U-Boot DTB
+UBOOT_DTB_NAME = "imx8mm-var-dart-customboard.dtb"
+UBOOT_DTB_EXTRA = "imx8mm-var-som-symphony.dtb"
+
+# Set imx-mkimage boot target
+IMXBOOT_TARGETS = "flash_lpddr4_ddr4_evk"
+
+SERIAL_CONSOLES = "115200;ttymxc0 115200;ttymxc3"
+
+IMAGE_BOOTLOADER = "imx-boot"
+
+LOADADDR = ""
+UBOOT_SUFFIX = "bin"
+UBOOT_MAKE_TARGET = ""
+IMX_BOOT_SEEK = "33"

--- a/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mm-var-som.conf
+++ b/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mm-var-som.conf
@@ -3,6 +3,6 @@
 ##@DESCRIPTION: Machine configuration for the imx8mm-var-som
 
 MACHINEOVERRIDES = "imx8mm-var-dart:${MACHINE}"
-include conf/machine/imx8mm-var-dart.conf
+include conf/machine/imx8mm-var-dart.inc
 
 SERIAL_CONSOLES_imx8mm-var-som = "115200;ttymxc3"

--- a/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mq-var-dart.inc
+++ b/layers/meta-balena-imx8m-var-dart/conf/machine/imx8mq-var-dart.inc
@@ -1,0 +1,74 @@
+#@TYPE: Machine
+#@NAME: Variscite DART-MX8M
+#@SOC: i.MX8MQ
+#@DESCRIPTION: Machine configuration for Variscite DART-MX8M
+#@MAINTAINER: Felix Radensky <felix.r@variscite.com>
+#
+# http://www.variscite.com
+
+MACHINEOVERRIDES =. "mx8:mx8m:mx8mq:"
+require conf/machine/include/imx-base.inc
+require conf/machine/include/tune-cortexa53.inc
+
+require conf/machine/variscite.inc
+require conf/machine/variscite_bcm43xx.inc
+
+KERNEL_DEVICETREE = " \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-m4-sd-dp.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-m4-sd-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-m4-sd-lvds-dp.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-m4-sd-lvds.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-m4-sd-lvds-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-m4-wifi-dp.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-m4-wifi-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-m4-wifi-lvds-dp.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-m4-wifi-lvds.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-m4-wifi-lvds-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-sd-dp.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-sd-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-sd-lvds-dp.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-sd-lvds.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-sd-lvds-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-wifi-dp.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-wifi-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-wifi-lvds-dp.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-wifi-lvds.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-legacy-wifi-lvds-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-m4-sd-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-m4-sd-lvds.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-m4-sd-lvds-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-m4-wifi-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-m4-wifi-lvds.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-m4-wifi-lvds-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-sd-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-sd-lvds.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-sd-lvds-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-wifi-hdmi.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-wifi-lvds.dtb \
+	freescale/imx8mq-var-dart-dt8mcustomboard-wifi-lvds-hdmi.dtb \
+"
+
+IMAGE_BOOTFILES_DEPENDS += "imx-m4-demos:do_deploy"
+IMAGE_BOOTFILES += "imx8mq_m4_TCM_hello_world.bin imx8mq_m4_TCM_rpmsg_lite_pingpong_rtos_linux_remote.bin imx8mq_m4_TCM_rpmsg_lite_str_echo_rtos.bin"
+
+UBOOT_CONFIG ??= "sd"
+UBOOT_CONFIG[sd] = "imx8mq_var_dart_config,sdcard"
+SPL_BINARY = "spl/u-boot-spl.bin"
+
+# Set DDR FIRMWARE
+DDR_FIRMWARE_NAME = "lpddr4_pmu_train_1d_imem.bin lpddr4_pmu_train_1d_dmem.bin lpddr4_pmu_train_2d_imem.bin lpddr4_pmu_train_2d_dmem.bin"
+
+# Set U-Boot DTB
+UBOOT_DTB_NAME = "imx8mq-var-dart-customboard.dtb"
+
+# Set imx-mkimage boot target
+IMXBOOT_TARGETS = "flash_evk flash_evk_no_hdmi flash_dp_evk"
+
+SERIAL_CONSOLES = "115200;ttymxc0"
+
+IMAGE_BOOTLOADER = "imx-boot"
+
+LOADADDR = ""
+UBOOT_SUFFIX = "bin"
+UBOOT_MAKE_TARGET = ""
+IMX_BOOT_SEEK = "33"


### PR DESCRIPTION
balenaOS needs this variable to reflect the real size of the root filesysem.

Changelog-entry: do not set ROOTFS_SIZE in machine configuration
Signed-off-by: Alex Gonzalez <alexg@balena.io>