### PR TITLE
recipes-core/images: Don't install extra_uEnv.txt in flasher image

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-imx8m-var-dart/recipes-core/images/balena-image.inc
@@ -41,10 +41,6 @@ BALENA_BOOT_PARTITION_FILES_imx8mm-var-dart = " \
     imx8mm-var-dart-dt8mcustomboard-m4.dtb:/imx8mm-var-dart-dt8mcustomboard-m4.dtb \
 "
 
-BALENA_BOOT_PARTITION_FILES_append = " \
-    extra_uEnv.txt:/extra_uEnv.txt \
-"
-
 IMAGE_INSTALL_append = " \
 	imx-boot \
 	bcm43xx-utils \


### PR DESCRIPTION
The extra_uEnv.txt file is installed by meta-balena in the non-flasher image so that it can be manipulated by the supervisor, but there's no other reason for including it in the flasher by the yocto build.

This was a leftover from testing the custom dtbs during provisioning, let's remove it because it causes problems for the nodejs file manipulation library during provisioning of boards which use a button for toggling boot from sd-cards.

Changelog-entry: recipes-core/images: Don't install extra_uEnv.txt in flasher image