### PR TITLE
balena-image-initramfs: Add back migrate initramfs module

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-core/images/balena-image-initramfs.bbappend
@@ -3,4 +3,3 @@ IMAGE_FSTYPES_imx8m-var-dart  = "${INITRAMFS_FSTYPES}"
 IMAGE_FSTYPES_imx8mm-var-dart = "${INITRAMFS_FSTYPES}"
 
 PACKAGE_INSTALL_remove = " initramfs-module-recovery"
-PACKAGE_INSTALL_remove = " initramfs-module-migrate"


### PR DESCRIPTION
On other devices we noticed that the mnt-sysroot-inactive.mount unit cannot activate during first boot after provisioning, unless it is restarted. The automount hangs only during the first boot, upon reboot starts working normally.

We add back the migrate module to avoid potential cases like this.

Changelog-entry: balena-image-initramfs: Add back migrate initramfs module