### PR TITLE
imx-boot: ensure boot binary is not reused from sstate

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-bsp/imx-mkimage/imx-boot_1.0.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-bsp/imx-mkimage/imx-boot_1.0.bbappend
@@ -1,0 +1,6 @@
+DEPENDS_append = " \
+    virtual/bootloader \
+"
+do_configure[nostamp] = "1"
+do_compile[depends] += "virtual/bootloader:do_deploy"
+do_compile[nostamp] = "1"


### PR DESCRIPTION
Changelog-entry: imx-boot: ensure boot binary is not reused from sstate
Signed-of-by: Alexandru Costache <alexandru@balena.io>