### PR TITLE
bluez: Increase scan duration and make sure caches are flushed

### DIFF
--- a/layers/meta-balena-imx8m-var-dart/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-balena-imx8m-var-dart/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:append := ":${THISDIR}/files"
+
+# Increase scan duration and make sure caches are flushed
+# to overcome autokit sporadic scan reporting no results.
+# Scanning appears to work fine outside autokit on the PLT
+# device and this could be caused by interferences and
+# caching.
+SRC_URI:append:imx8mm-var-dart-plt += " \
+    file://0005-scan_len.patch \
+"

--- a/layers/meta-balena-imx8m-var-dart/recipes-connectivity/bluez5/files/0005-scan_len.patch
+++ b/layers/meta-balena-imx8m-var-dart/recipes-connectivity/bluez5/files/0005-scan_len.patch
@@ -1,0 +1,29 @@
+Increase scan duration and make sure caches are flushed
+to overcome autokit sporadic scan reporting no results.
+
+The scan appears to work fine outside autokit on the PLT
+device and this could be caused by interferences and
+caching.
+
+Index: bluez-5.66/tools/hcitool.c
+===================================================================
+--- bluez-5.66.orig/tools/hcitool.c
++++ bluez-5.66/tools/hcitool.c
+@@ -571,7 +571,7 @@ static void cmd_scan(int dev_id, int arg
+ 	int extcls = 0, extinf = 0, extoui = 0;
+ 	int i, n, l, opt, dd, cc;
+ 
+-	length  = 8;	/* ~10 seconds */
++	length  = 24;	/* ~30 seconds */
+ 	num_rsp = 0;
+ 	flags   = 0;
+ 
+@@ -641,7 +641,7 @@ static void cmd_scan(int dev_id, int arg
+ 		perror("Can't get device info");
+ 		exit(1);
+ 	}
+-
++	flags |= IREQ_CACHE_FLUSH;
+ 	printf("Scanning ...\n");
+ 	num_rsp = hci_inquiry(dev_id, length, num_rsp, lap, &info, flags);
+ 	if (num_rsp < 0) {


### PR DESCRIPTION
... to work around autokit sporadic scan reporting no results.

The scan appears to work fine outside autokit on the PLT device and this could be caused by interferences and caching.

Changelog-entry: Increase BT scan length, flush caches on PLT